### PR TITLE
`Native` used as default platform

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -86,15 +86,15 @@ pub struct InitArgs {
     #[clap(value_enum, short, long)]
     pub language: Option<TargetLanguage>,
 
-    #[clap(value_enum, short, long)]
-    pub platform: Option<Platform>,
+    #[clap(value_enum, short, long, default_value_t = Platform::Native)]
+    pub platform: Platform,
 }
 impl InitArgs {
     pub fn get_target_language(&self) -> TargetLanguage {
         self.language.unwrap_or({
             // Target language for Zephyr is C, else Cpp.
             match self.platform {
-                Some(Platform::Zephyr) => TargetLanguage::C,
+                Platform::Zephyr => TargetLanguage::C,
                 _ => TargetLanguage::Cpp,
             }
         })

--- a/src/package/mod.rs
+++ b/src/package/mod.rs
@@ -156,7 +156,7 @@ impl ConfigFile {
                 name: Some(spec.name),
                 main_reactor: Some(spec.path),
                 target: spec.target,
-                platform: init_args.platform,
+                platform: Some(init_args.platform),
                 dependencies: HashMap::new(),
                 properties: HashMap::new(),
             })


### PR DESCRIPTION
The platform was an optional value now it defaults to `Native`. Hence, when lingo init was called, no HelloWorld code was generated. 